### PR TITLE
Adds line number to unexpectedToken syntax error

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,7 +221,7 @@ exports.parse = function (source, _, options) {
   }
 
   function unexpectedToken() {
-    throw new SyntaxError('Unexpected token ' + source[pos] + ' in JSON at position ' + pos);
+    throw new SyntaxError('Unexpected token ' + source[pos] + ' in JSON at position ' + pos + ' on line ' +line);
   }
 
   function wasUnexpectedToken() {


### PR DESCRIPTION
When utilizing json-source-map to validate JSON - I wanted to display invalid JSON errors to the user at the specific line at which it occurred, but noticed that the syntax errors that were being thrown only passed in the position and not the line number.