### PR TITLE
Feature/ `jsonc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Location object has properties (zero-based numbers):
 
 Options:
 - _bigint_: parse large integers as [BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt).
+- _jsonc_: parse as [jsonc](https://code.visualstudio.com/docs/languages/json#_json-with-comments).
 
 Whitespace:
 - the only character that increases line number in mappings is line feed ('\n'), so if your JSON string has '\r\n' sequence, it will still be counted as one line,

--- a/index.js
+++ b/index.js
@@ -58,10 +58,58 @@ exports.parse = function (source, _, options) {
           case '\t': column += 4; break;
           case '\r': column = 0; break;
           case '\n': column = 0; line++; break;
+          case '/': pos++; parseComment(); continue;
           default: break loop;
         }
         pos++;
       }
+  }
+
+  function parseComment() {
+    var commentStr = '/';
+    var nextChar = getChar();
+    commentStr += nextChar;
+
+    if (nextChar === '/') {
+      // read until `\n`
+      singleLineComment: {
+        while (true) {
+          nextChar = getChar();
+
+          if (nextChar === '\n') {
+            line++;
+            break singleLineComment;
+          }
+
+          commentStr += nextChar;
+        }
+      }
+    } else if (nextChar === '*') {
+      // read until `*/`
+      multiLineComment: {
+        while (true) {
+          nextChar = getChar();
+
+          if (nextChar === '\n')
+            line++;
+
+          if (nextChar === '*') {
+            commentStr += nextChar;
+            nextChar = getChar();
+            commentStr += nextChar;
+
+            if (nextChar === '/')
+              break multiLineComment;
+          }
+
+          commentStr += nextChar;
+        }
+      }
+    } else {
+      wasUnexpectedToken();
+    }
+
+    return commentStr;
   }
 
   function parseString() {

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ exports.parse = function (source, _, options) {
           case '\n': column = 0; line++; break;
           case '/':
             if (!jsonc) break loop;
-            pos++;
+            column++; pos++;
             parseComment();
             continue loop;
           default: break loop;

--- a/index.js
+++ b/index.js
@@ -60,8 +60,10 @@ exports.parse = function (source, _, options) {
           case '\r': column = 0; break;
           case '\n': column = 0; line++; break;
           case '/':
-            if (jsonc) { pos++; parseComment(); continue; }
-            break loop;
+            if (!jsonc) break loop;
+            pos++;
+            parseComment();
+            continue loop;
           default: break loop;
         }
         pos++;
@@ -170,11 +172,11 @@ exports.parse = function (source, _, options) {
     whitespace();
 
     readEarlyCommas: while (jsonc) {
-      char = getChar();
-      if (char == ']') return arr;
-      if (char == ',') { whitespace(); continue; }
-      backChar();
-      break readEarlyCommas;
+      switch (getChar()) {
+        case ']': return arr;
+        case ',': whitespace(); continue readEarlyCommas;
+        default: backChar(); break readEarlyCommas;
+      }
     }
 
     readArray: while (true) {
@@ -186,13 +188,12 @@ exports.parse = function (source, _, options) {
       if (char != ',') wasUnexpectedToken();
       whitespace();
       readTrailingCommas: while (jsonc) {
-        char = getChar();
-        if (char == ']') break readArray;
-        if (char == ',') { whitespace(); continue; }
-        backChar();
-        break readTrailingCommas;
+        switch (getChar()) {
+          case ']': break readArray;
+          case ',': whitespace(); continue readTrailingCommas;
+          default: backChar(); break readTrailingCommas;
+        }
       }
-      whitespace();
       i++;
     }
     return arr;
@@ -207,11 +208,11 @@ exports.parse = function (source, _, options) {
     whitespace();
 
     readEarlyCommas: while (jsonc) {
-      char = getChar();
-      if (char == '}') return obj;
-      if (char == ',') { whitespace(); continue; }
-      backChar();
-      break readEarlyCommas;
+      switch (getChar()) {
+        case '}': return obj;
+        case ',': whitespace(); continue readEarlyCommas;
+        default: backChar(); break readEarlyCommas;
+      }
     }
 
     readObject: while (true) {
@@ -231,11 +232,11 @@ exports.parse = function (source, _, options) {
       if (char != ',') wasUnexpectedToken();
       whitespace();
       readTrailingCommas: while (jsonc) {
-        char = getChar();
-        if (char == '}') break readObject;
-        if (char == ',') { whitespace(); continue; }
-        backChar();
-        break readTrailingCommas;
+        switch (getChar()) {
+          case '}': break readObject;
+          case ',': whitespace(); continue readTrailingCommas;
+          default: backChar(); break readTrailingCommas;
+        }
       }
     }
     return obj;

--- a/index.js
+++ b/index.js
@@ -169,14 +169,15 @@ exports.parse = function (source, _, options) {
     backChar();
     whitespace();
 
+    readEarlyCommas: while (jsonc) {
+      char = getChar();
+      if (char == ']') return arr;
+      if (char == ',') { whitespace(); continue; }
+      backChar();
+      break readEarlyCommas;
+    }
+
     readArray: while (true) {
-      readEarlyCommas: while (jsonc) {
-        char = getChar();
-        if (char == ']') break readArray;
-        if (char == ',') { whitespace(); continue; }
-        backChar();
-        break readEarlyCommas;
-      }
       var itemPtr = ptr + '/' + i;
       arr.push(_parse(itemPtr));
       whitespace();
@@ -205,14 +206,15 @@ exports.parse = function (source, _, options) {
     backChar();
     whitespace();
 
+    readEarlyCommas: while (jsonc) {
+      char = getChar();
+      if (char == '}') return obj;
+      if (char == ',') { whitespace(); continue; }
+      backChar();
+      break readEarlyCommas;
+    }
+
     readObject: while (true) {
-      readEarlyCommas: while (jsonc) {
-        char = getChar();
-        if (char == '}') break readObject;
-        if (char == ',') { whitespace(); continue; }
-        backChar();
-        break readEarlyCommas;
-      }
       var loc = getLoc();
       if (getChar() != '"') wasUnexpectedToken();
       var key = parseString();

--- a/index.js
+++ b/index.js
@@ -73,43 +73,36 @@ exports.parse = function (source, _, options) {
     var nextChar = getChar();
     commentStr += nextChar;
 
-    if (nextChar === '/') {
-      // read until `\n`
-      singleLineComment: {
-        while (true) {
-          nextChar = getChar();
+    var singleLineComment = nextChar === '/';
+    var multiLineComment = nextChar === '*';
 
-          if (nextChar === '\n') {
-            line++;
-            break singleLineComment;
-          }
-
-          commentStr += nextChar;
-        }
-      }
-    } else if (nextChar === '*') {
-      // read until `*/`
-      multiLineComment: {
-        while (true) {
-          nextChar = getChar();
-
-          if (nextChar === '\n')
-            line++;
-
-          if (nextChar === '*') {
-            commentStr += nextChar;
-            nextChar = getChar();
-            commentStr += nextChar;
-
-            if (nextChar === '/')
-              break multiLineComment;
-          }
-
-          commentStr += nextChar;
-        }
-      }
-    } else {
+    if (!singleLineComment && !multiLineComment)
       wasUnexpectedToken();
+
+    if (multiLineComment && source[pos] === '*')
+      getChar();
+
+    readComment: {
+      while (true) {
+        nextChar = getChar();
+
+        if (nextChar === '\n') {
+          line++;
+          if (singleLineComment)
+            break readComment;
+        }
+
+        if (multiLineComment && nextChar === '*') {
+          commentStr += nextChar;
+          nextChar = getChar();
+          commentStr += nextChar;
+
+          if (nextChar === '/')
+            break readComment;
+        }
+
+        commentStr += nextChar;
+      }
     }
 
     return commentStr;

--- a/index.js
+++ b/index.js
@@ -179,6 +179,7 @@ exports.parse = function (source, _, options) {
       if (char == ']') break;
       if (char != ',') wasUnexpectedToken();
       whitespace();
+      if (jsonc && source[pos] == ']') {getChar(); break;}
       i++;
     }
     return arr;
@@ -206,6 +207,7 @@ exports.parse = function (source, _, options) {
       if (char == '}') break;
       if (char != ',') wasUnexpectedToken();
       whitespace();
+      if (jsonc && source[pos] == '}') {getChar(); break;}
     }
     return obj;
   }

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ exports.parse = function (source, _, options) {
   var line = 0;
   var column = 0;
   var pos = 0;
+  var jsonc = !!(options && options.jsonc && typeof options.jsonc != 'undefined');
   var bigint = options && options.bigint && typeof BigInt != 'undefined';
   return {
     data: _parse('', true),
@@ -58,7 +59,9 @@ exports.parse = function (source, _, options) {
           case '\t': column += 4; break;
           case '\r': column = 0; break;
           case '\n': column = 0; line++; break;
-          case '/': pos++; parseComment(); continue;
+          case '/':
+            if (jsonc) { pos++; parseComment(); continue; }
+            break loop;
           default: break loop;
         }
         pos++;

--- a/index.js
+++ b/index.js
@@ -69,18 +69,14 @@ exports.parse = function (source, _, options) {
   }
 
   function parseComment() {
-    var commentStr = '/';
     var nextChar = getChar();
-    commentStr += nextChar;
-
     var singleLineComment = nextChar === '/';
     var multiLineComment = nextChar === '*';
 
     if (!singleLineComment && !multiLineComment)
       wasUnexpectedToken();
 
-    if (multiLineComment && source[pos] === '*')
-      getChar();
+    var commentStr = '/' + nextChar;
 
     readComment: {
       while (true) {

--- a/spec/index.js
+++ b/spec/index.js
@@ -339,6 +339,46 @@ describe('parse', function() {
       "/prop5/4":{"value":{"line":19,"column":8,"pos":388},"valueEnd":{"line":19,"column":9,"pos":389}}
     };
 
+    const simpleJsonc =
+    `/* Simple jsonc*/{ "prop1": "test1" }`;
+    const expectedSimpleJsonc = { prop1: "test1" };
+    const pointersSimpleJsonc = {
+      "": {
+        "value": {
+          "column": 16,
+          "line": 0,
+          "pos": 17,
+        },
+        "valueEnd": {
+          "column": 36,
+          "line": 0,
+          "pos": 37,
+        },
+      },
+      "/prop1": {
+        "key": {
+          "column": 18,
+          "line": 0,
+          "pos": 19
+        },
+        "keyEnd": {
+          "column": 25,
+          "line": 0,
+          "pos": 26
+        },
+        "value": {
+          "column": 27,
+          "line": 0,
+          "pos": 28
+        },
+        "valueEnd": {
+          "column": 34,
+          "line": 0,
+          "pos": 35
+        }
+      }
+    };
+
     const badJsonc = `{ "prop1": "test" / }`;
     const badJsoncArr = `[ "test" / ]`;
     const tooManyExits = `{ "prop1": "test" /* */ */ }`;
@@ -352,6 +392,8 @@ describe('parse', function() {
     it("Should parse json with comments and trailing commas as whitespace and execute as normal if jsonc true", () => {
       assert.deepStrictEqual(jsonMap.parse(jsonc, null, { jsonc: true }).data, expectedJsonc);
       assert.deepStrictEqual(jsonMap.parse(jsonc, null, { jsonc: true }).pointers, expectedPointers);
+      assert.deepStrictEqual(jsonMap.parse(simpleJsonc, null, { jsonc: true }).data, expectedSimpleJsonc);
+      assert.deepStrictEqual(jsonMap.parse(simpleJsonc, null, { jsonc: true }).pointers, pointersSimpleJsonc);
     });
 
     it("Should throw errors on a / not followed by a * or another /", () => {

--- a/spec/index.js
+++ b/spec/index.js
@@ -292,6 +292,28 @@ describe('parse', function() {
     });
   });
 
+  describe("jsonc", () => {
+    const jsonc =
+`{
+  // Hello World
+  "prop1": "test",
+  // Test
+  "prop2": "test2"
+  /* Hello World */,
+  "prop3": [ 123, /* Hello World */ "456", /* Hello World */ 789 ] /* Hello World */,
+  "prop4" /* Hello World*/ : "test3"
+}`;
+
+    const badJsonc = `{ "prop1": "test" / }`;
+
+    it("Should parse jsonc comments as whitespace and execute as normal", () => {
+      assert.deepStrictEqual(jsonMap.parse(jsonc).data, { "prop1": "test", "prop2": "test2", "prop3": [123, "456", 789], "prop4": "test3" });
+    });
+
+    it("Should throw errors on a / not followed by a * or another /", () => {
+      assert.throws(() => jsonMap.parse(badJsonc), "Unexpected token   in JSON at position 18");
+    });
+  });
 
   function testParse(json, expectedData, skipReverseCheck, whitespace) {
     var result = jsonMap.parse(json);

--- a/spec/index.js
+++ b/spec/index.js
@@ -323,20 +323,72 @@ describe('parse', function() {
 }`;
     const expectedJsonc = { prop1: "test", prop2: "test2", prop3: [123, "456", 789], prop4: "test3", prop5: [0, 1, 2, 3, 4] };
     const expectedPointers = {
-      "":{"value":{"line":0,"column":0,"pos":0},"valueEnd":{"line":27,"column":1,"pos":503}},
-      "/prop1":{"key":{"line":2,"column":2,"pos":21},"keyEnd":{"line":2,"column":9,"pos":28},"value":{"line":2,"column":11,"pos":30},"valueEnd":{"line":2,"column":17,"pos":36}},
-      "/prop2":{"key":{"line":4,"column":2,"pos":50},"keyEnd":{"line":4,"column":9,"pos":57},"value":{"line":4,"column":11,"pos":59},"valueEnd":{"line":4,"column":18,"pos":66}},
-      "/prop3":{"key":{"line":6,"column":2,"pos":90},"keyEnd":{"line":6,"column":9,"pos":97},"value":{"line":6,"column":11,"pos":99},"valueEnd":{"line":6,"column":66,"pos":156}},
-      "/prop3/0":{"value":{"line":6,"column":13,"pos":101},"valueEnd":{"line":6,"column":16,"pos":104}},
-      "/prop3/1":{"value":{"line":6,"column":35,"pos":124},"valueEnd":{"line":6,"column":40,"pos":129}},
-      "/prop3/2":{"value":{"line":6,"column":61,"pos":151},"valueEnd":{"line":6,"column":64,"pos":154}},
-      "/prop4":{"key":{"line":7,"column":2,"pos":178},"keyEnd":{"line":7,"column":9,"pos":185},"value":{"line":7,"column":35,"pos":212},"valueEnd":{"line":7,"column":42,"pos":219}},
-      "/prop5":{"key":{"line":8,"column":2,"pos":226},"keyEnd":{"line":8,"column":9,"pos":233},"value":{"line":8,"column":11,"pos":235},"valueEnd":{"line":20,"column":3,"pos":394}},
-      "/prop5/0":{"value":{"line":15,"column":4,"pos":332},"valueEnd":{"line":15,"column":5,"pos":333}},
-      "/prop5/1":{"value":{"line":16,"column":4,"pos":339},"valueEnd":{"line":16,"column":5,"pos":340}},
-      "/prop5/2":{"value":{"line":19,"column":2,"pos":382},"valueEnd":{"line":19,"column":3,"pos":383}},
-      "/prop5/3":{"value":{"line":19,"column":5,"pos":385},"valueEnd":{"line":19,"column":6,"pos":386}},
-      "/prop5/4":{"value":{"line":19,"column":8,"pos":388},"valueEnd":{"line":19,"column":9,"pos":389}}
+      '': {
+        value: { line: 0, column: 0, pos: 0 },
+        valueEnd: { line: 27, column: 1, pos: 503 }
+      },
+      '/prop1': {
+        key: { line: 2, column: 2, pos: 21 },
+        keyEnd: { line: 2, column: 9, pos: 28 },
+        value: { line: 2, column: 11, pos: 30 },
+        valueEnd: { line: 2, column: 17, pos: 36 }
+      },
+      '/prop2': {
+        key: { line: 4, column: 2, pos: 50 },
+        keyEnd: { line: 4, column: 9, pos: 57 },
+        value: { line: 4, column: 11, pos: 59 },
+        valueEnd: { line: 4, column: 18, pos: 66 }
+      },
+      '/prop3': {
+        key: { line: 6, column: 2, pos: 90 },
+        keyEnd: { line: 6, column: 9, pos: 97 },
+        value: { line: 6, column: 11, pos: 99 },
+        valueEnd: { line: 6, column: 68, pos: 156 }
+      },
+      '/prop3/0': {
+        value: { line: 6, column: 13, pos: 101 },
+        valueEnd: { line: 6, column: 16, pos: 104 }
+      },
+      '/prop3/1': {
+        value: { line: 6, column: 36, pos: 124 },
+        valueEnd: { line: 6, column: 41, pos: 129 }
+      },
+      '/prop3/2': {
+        value: { line: 6, column: 63, pos: 151 },
+        valueEnd: { line: 6, column: 66, pos: 154 }
+      },
+      '/prop4': {
+        key: { line: 7, column: 2, pos: 178 },
+        keyEnd: { line: 7, column: 9, pos: 185 },
+        value: { line: 7, column: 36, pos: 212 },
+        valueEnd: { line: 7, column: 43, pos: 219 }
+      },
+      '/prop5': {
+        key: { line: 8, column: 2, pos: 226 },
+        keyEnd: { line: 8, column: 9, pos: 233 },
+        value: { line: 8, column: 11, pos: 235 },
+        valueEnd: { line: 20, column: 3, pos: 394 }
+      },
+      '/prop5/0': {
+        value: { line: 15, column: 4, pos: 332 },
+        valueEnd: { line: 15, column: 5, pos: 333 }
+      },
+      '/prop5/1': {
+        value: { line: 16, column: 4, pos: 339 },
+        valueEnd: { line: 16, column: 5, pos: 340 }
+      },
+      '/prop5/2': {
+        value: { line: 19, column: 2, pos: 382 },
+        valueEnd: { line: 19, column: 3, pos: 383 }
+      },
+      '/prop5/3': {
+        value: { line: 19, column: 5, pos: 385 },
+        valueEnd: { line: 19, column: 6, pos: 386 }
+      },
+      '/prop5/4': {
+        value: { line: 19, column: 8, pos: 388 },
+        valueEnd: { line: 19, column: 9, pos: 389 }
+      }
     };
 
     const simpleJsonc =
@@ -345,34 +397,34 @@ describe('parse', function() {
     const pointersSimpleJsonc = {
       "": {
         "value": {
-          "column": 16,
+          "column": 17,
           "line": 0,
           "pos": 17,
         },
         "valueEnd": {
-          "column": 36,
+          "column": 37,
           "line": 0,
           "pos": 37,
         },
       },
       "/prop1": {
         "key": {
-          "column": 18,
+          "column": 19,
           "line": 0,
           "pos": 19
         },
         "keyEnd": {
-          "column": 25,
+          "column": 26,
           "line": 0,
           "pos": 26
         },
         "value": {
-          "column": 27,
+          "column": 28,
           "line": 0,
           "pos": 28
         },
         "valueEnd": {
-          "column": 34,
+          "column": 35,
           "line": 0,
           "pos": 35
         }

--- a/spec/index.js
+++ b/spec/index.js
@@ -306,7 +306,8 @@ describe('parse', function() {
 
     const badJsonc = `{ "prop1": "test" / }`;
 
-    const jsonWithTrailingComma = `{ "prop1": "test1", "prop2": [1, 2, 3,]     , }`;
+    const jsonWithTrailingComma = `{ "prop1": "test1", "prop2": [1, 2, 3,] }`;
+    const jsonObjWithTrailingComma = `{ "prop1": "test1", "prop2": [1, 2, 3]     , }`;
 
     it("Should parse jsonc comments as whitespace and execute as normal if jsonc true", () => {
       assert.deepStrictEqual(jsonMap.parse(jsonc, null, { jsonc: true }).data, { "prop1": "test", "prop2": "test2", "prop3": [123, "456", 789], "prop4": "test3" });
@@ -320,11 +321,12 @@ describe('parse', function() {
       assert.throws(() => jsonMap.parse(badJsonc, null, { jsonc: true }), /Unexpected token[ ]{3}in JSON at position 19/, "Didn't throw error for unterminated multiline string");
     });
 
-    it("Should throw errors for invalid json if jsonc option false or not given and json contains comments", () => {
+    it("Should throw errors for invalid json if jsonc option false or not given and json contains comments or trailing commas", () => {
       assert.throws(() => jsonMap.parse(jsonc, null, { jsonc: false }), /Unexpected token [/] in JSON at position 4/, "Didn't throw error when jsonc option false and comments in json.");
       assert.throws(() => jsonMap.parse(jsonc, null, {}), /Unexpected token [/] in JSON at position 4/, "Didn't throw error when empty options given and comments in json.");
       assert.throws(() => jsonMap.parse(jsonc), /Unexpected token [/] in JSON at position 4/, "Didn't throw error when jsonc not given and comments in json.");
-      assert.throws(() => jsonMap.parse(jsonWithTrailingComma), /Unexpected token ] in JSON at position 38/, "Didn't throw error when jsonc not given and trailing commas in json.");
+      assert.throws(() => jsonMap.parse(jsonWithTrailingComma), /Unexpected token ] in JSON at position 38/, "Didn't throw error when jsonc not given and trailing comma in array.");
+      assert.throws(() => jsonMap.parse(jsonObjWithTrailingComma), /Unexpected token } in JSON at position 45/, "Didn't throw error when jsonc not given and trailing comma in object.");
     });
   });
 

--- a/spec/index.js
+++ b/spec/index.js
@@ -294,22 +294,34 @@ describe('parse', function() {
 
   describe("jsonc", () => {
     const jsonc =
-`{
-  // Hello World
-  "prop1": "test",
-  // Test
-  "prop2": "test2"
-  /* Hello World */,
-  "prop3": [ 123, /* Hello World */ "456", /* Hello World */ 789 ] /* Hello World */,
-  "prop4" /* Hello World*/ : "test3",
-  // /**********
-  /**
-   *
-   * Multi line Big Comment
-   */
-  /// Header
-  /// Subtext
-}`;
+    `{
+      // Hello World
+      "prop1": "test",
+      // Test
+      "prop2": "test2"
+      /* Hello World */,
+      "prop3": [ 123, /* Hello World */ "456",,, /* Hello World */ 789 ] /* Hello World */,
+      "prop4" /* Hello World ,,, * */ : "test3",,,,
+      "prop5": [
+        // Hello World!
+        /// Header
+        // /* */
+        0,
+        1, /* Hello World!
+        ,,,,,,,,,,
+        */
+      2, 3, 4,
+      ],
+      // /**********
+      /**
+       *
+       * Multi line Big Comment
+       */
+      /// Header
+      /// Subtext
+      ,,,,,,,,,,,,,,
+    }`;
+    const expectedJsonc = { prop1: "test", prop2: "test2", prop3: [123, "456", 789], prop4: "test3", prop5: [0, 1, 2, 3, 4] };
 
     const badJsonc = `{ "prop1": "test" / }`;
     const badJsoncArr = `[ "test" / ]`;
@@ -322,11 +334,11 @@ describe('parse', function() {
     const jsonObjWithTrailingComma = `{ "prop1": "test1", "prop2": [1, 2, 3]     , }`;
 
     it("Should parse jsonc comments as whitespace and execute as normal if jsonc true", () => {
-      assert.deepStrictEqual(jsonMap.parse(jsonc, null, { jsonc: true }).data, { "prop1": "test", "prop2": "test2", "prop3": [123, "456", 789], "prop4": "test3" });
+      assert.deepStrictEqual(jsonMap.parse(jsonc, null, { jsonc: true }).data, expectedJsonc);
     });
 
     it("Should parse trailing commas as valid if jsonc true", () => {
-      assert.deepStrictEqual(jsonMap.parse(jsonc, null, { jsonc: true }).data, { "prop1": "test", "prop2": "test2", "prop3": [123, "456", 789], "prop4": "test3" });
+      assert.deepStrictEqual(jsonMap.parse(jsonc, null, { jsonc: true }).data, expectedJsonc);
     });
 
     it("Should throw errors on a / not followed by a * or another /", () => {
@@ -339,9 +351,9 @@ describe('parse', function() {
     });
 
     it("Should throw errors for invalid json if jsonc option false or not given and json contains comments or trailing commas", () => {
-      assert.throws(() => jsonMap.parse(jsonc, null, { jsonc: false }), /Unexpected token \/ in JSON at position 4/);
-      assert.throws(() => jsonMap.parse(jsonc, null, {}), /Unexpected token \/ in JSON at position 4/);
-      assert.throws(() => jsonMap.parse(jsonc), /Unexpected token \/ in JSON at position 4/);
+      assert.throws(() => jsonMap.parse(jsonc, null, { jsonc: false }), /Unexpected token \/ in JSON at position 8/);
+      assert.throws(() => jsonMap.parse(jsonc, null, {}), /Unexpected token \/ in JSON at position 8/);
+      assert.throws(() => jsonMap.parse(jsonc), /Unexpected token \/ in JSON at position 8/);
       assert.throws(() => jsonMap.parse(jsonWithTrailingComma), /Unexpected token ] in JSON at position 38/);
       assert.throws(() => jsonMap.parse(jsonObjWithTrailingComma), /Unexpected token } in JSON at position 45/);
     });

--- a/spec/index.js
+++ b/spec/index.js
@@ -324,7 +324,7 @@ describe('parse', function() {
       assert.throws(() => jsonMap.parse(jsonc, null, { jsonc: false }), /Unexpected token [/] in JSON at position 4/, "Didn't throw error when jsonc option false and comments in json.");
       assert.throws(() => jsonMap.parse(jsonc, null, {}), /Unexpected token [/] in JSON at position 4/, "Didn't throw error when empty options given and comments in json.");
       assert.throws(() => jsonMap.parse(jsonc), /Unexpected token [/] in JSON at position 4/, "Didn't throw error when jsonc not given and comments in json.");
-      assert.throws(() => jsonMap.parse(jsonWithTrailingComma), /Unexpected token ] in JSON at position 38/, "Didn't throw error when jsonc not given and comments in json.");
+      assert.throws(() => jsonMap.parse(jsonWithTrailingComma), /Unexpected token ] in JSON at position 38/, "Didn't throw error when jsonc not given and trailing commas in json.");
     });
   });
 

--- a/spec/index.js
+++ b/spec/index.js
@@ -301,12 +301,18 @@ describe('parse', function() {
   "prop2": "test2"
   /* Hello World */,
   "prop3": [ 123, /* Hello World */ "456", /* Hello World */ 789 ] /* Hello World */,
-  "prop4" /* Hello World*/ : "test3"
+  "prop4" /* Hello World*/ : "test3",
 }`;
 
     const badJsonc = `{ "prop1": "test" / }`;
 
-    it("Should parse jsonc comments as whitespace and execute as normal", () => {
+    const jsonWithTrailingComma = `{ "prop1": "test1", "prop2": [1, 2, 3,]     , }`;
+
+    it("Should parse jsonc comments as whitespace and execute as normal if jsonc true", () => {
+      assert.deepStrictEqual(jsonMap.parse(jsonc, null, { jsonc: true }).data, { "prop1": "test", "prop2": "test2", "prop3": [123, "456", 789], "prop4": "test3" });
+    });
+
+    it("Should parse trailing commas as valid if jsonc true", () => {
       assert.deepStrictEqual(jsonMap.parse(jsonc, null, { jsonc: true }).data, { "prop1": "test", "prop2": "test2", "prop3": [123, "456", 789], "prop4": "test3" });
     });
 
@@ -318,7 +324,7 @@ describe('parse', function() {
       assert.throws(() => jsonMap.parse(jsonc, null, { jsonc: false }), /Unexpected token [/] in JSON at position 4/, "Didn't throw error when jsonc option false and comments in json.");
       assert.throws(() => jsonMap.parse(jsonc, null, {}), /Unexpected token [/] in JSON at position 4/, "Didn't throw error when empty options given and comments in json.");
       assert.throws(() => jsonMap.parse(jsonc), /Unexpected token [/] in JSON at position 4/, "Didn't throw error when jsonc not given and comments in json.");
-
+      assert.throws(() => jsonMap.parse(jsonWithTrailingComma), /Unexpected token ] in JSON at position 38/, "Didn't throw error when jsonc not given and comments in json.");
     });
   });
 

--- a/spec/index.js
+++ b/spec/index.js
@@ -302,9 +302,21 @@ describe('parse', function() {
   /* Hello World */,
   "prop3": [ 123, /* Hello World */ "456", /* Hello World */ 789 ] /* Hello World */,
   "prop4" /* Hello World*/ : "test3",
+  // /**********
+  /**
+   *
+   * Multi line Big Comment
+   */
+  /// Header
+  /// Subtext
 }`;
 
     const badJsonc = `{ "prop1": "test" / }`;
+    const badJsoncArr = `[ "test" / ]`;
+    const tooManyExits = `{ "prop1": "test" /* */ */ }`;
+    const tooManyExitsArr = `{ "test" /* */ */ }`;
+    const unopenedComment = `{ Hello World! }`;
+    const unopenedCommentArr = `[ Hello World! ]`;
 
     const jsonWithTrailingComma = `{ "prop1": "test1", "prop2": [1, 2, 3,] }`;
     const jsonObjWithTrailingComma = `{ "prop1": "test1", "prop2": [1, 2, 3]     , }`;
@@ -318,15 +330,20 @@ describe('parse', function() {
     });
 
     it("Should throw errors on a / not followed by a * or another /", () => {
-      assert.throws(() => jsonMap.parse(badJsonc, null, { jsonc: true }), /Unexpected token[ ]{3}in JSON at position 19/, "Didn't throw error for unterminated multiline string");
+      assert.throws(() => jsonMap.parse(badJsonc, null, { jsonc: true }), /Unexpected token[ ]{3}in JSON at position 19/);
+      assert.throws(() => jsonMap.parse(badJsoncArr, null, { jsonc: true }), /Unexpected token[ ]{3}in JSON at position 10/);
+      assert.throws(() => jsonMap.parse(tooManyExits, null, { jsonc: true }), /Unexpected token \* in JSON at position 24/);
+      assert.throws(() => jsonMap.parse(tooManyExitsArr, null, { jsonc: true }), /Unexpected token \* in JSON at position 15/);
+      assert.throws(() => jsonMap.parse(unopenedComment, null, { jsonc: true }), /Unexpected token H in JSON at position 2/);
+      assert.throws(() => jsonMap.parse(unopenedCommentArr, null, { jsonc: true }), /Unexpected token H in JSON at position 2/);
     });
 
     it("Should throw errors for invalid json if jsonc option false or not given and json contains comments or trailing commas", () => {
-      assert.throws(() => jsonMap.parse(jsonc, null, { jsonc: false }), /Unexpected token [/] in JSON at position 4/, "Didn't throw error when jsonc option false and comments in json.");
-      assert.throws(() => jsonMap.parse(jsonc, null, {}), /Unexpected token [/] in JSON at position 4/, "Didn't throw error when empty options given and comments in json.");
-      assert.throws(() => jsonMap.parse(jsonc), /Unexpected token [/] in JSON at position 4/, "Didn't throw error when jsonc not given and comments in json.");
-      assert.throws(() => jsonMap.parse(jsonWithTrailingComma), /Unexpected token ] in JSON at position 38/, "Didn't throw error when jsonc not given and trailing comma in array.");
-      assert.throws(() => jsonMap.parse(jsonObjWithTrailingComma), /Unexpected token } in JSON at position 45/, "Didn't throw error when jsonc not given and trailing comma in object.");
+      assert.throws(() => jsonMap.parse(jsonc, null, { jsonc: false }), /Unexpected token \/ in JSON at position 4/);
+      assert.throws(() => jsonMap.parse(jsonc, null, {}), /Unexpected token \/ in JSON at position 4/);
+      assert.throws(() => jsonMap.parse(jsonc), /Unexpected token \/ in JSON at position 4/);
+      assert.throws(() => jsonMap.parse(jsonWithTrailingComma), /Unexpected token ] in JSON at position 38/);
+      assert.throws(() => jsonMap.parse(jsonObjWithTrailingComma), /Unexpected token } in JSON at position 45/);
     });
   });
 

--- a/spec/index.js
+++ b/spec/index.js
@@ -307,11 +307,18 @@ describe('parse', function() {
     const badJsonc = `{ "prop1": "test" / }`;
 
     it("Should parse jsonc comments as whitespace and execute as normal", () => {
-      assert.deepStrictEqual(jsonMap.parse(jsonc).data, { "prop1": "test", "prop2": "test2", "prop3": [123, "456", 789], "prop4": "test3" });
+      assert.deepStrictEqual(jsonMap.parse(jsonc, null, { jsonc: true }).data, { "prop1": "test", "prop2": "test2", "prop3": [123, "456", 789], "prop4": "test3" });
     });
 
     it("Should throw errors on a / not followed by a * or another /", () => {
-      assert.throws(() => jsonMap.parse(badJsonc), "Unexpected token   in JSON at position 18");
+      assert.throws(() => jsonMap.parse(badJsonc, null, { jsonc: true }), /Unexpected token[ ]{3}in JSON at position 19/, "Didn't throw error for unterminated multiline string");
+    });
+
+    it("Should throw errors for invalid json if jsonc option false or not given and json contains comments", () => {
+      assert.throws(() => jsonMap.parse(jsonc, null, { jsonc: false }), /Unexpected token [/] in JSON at position 4/, "Didn't throw error when jsonc option false and comments in json.");
+      assert.throws(() => jsonMap.parse(jsonc, null, {}), /Unexpected token [/] in JSON at position 4/, "Didn't throw error when empty options given and comments in json.");
+      assert.throws(() => jsonMap.parse(jsonc), /Unexpected token [/] in JSON at position 4/, "Didn't throw error when jsonc not given and comments in json.");
+
     });
   });
 

--- a/spec/index.js
+++ b/spec/index.js
@@ -294,34 +294,50 @@ describe('parse', function() {
 
   describe("jsonc", () => {
     const jsonc =
-    `{
-      // Hello World
-      "prop1": "test",
-      // Test
-      "prop2": "test2"
-      /* Hello World */,
-      "prop3": [ 123, /* Hello World */ "456",,, /* Hello World */ 789 ] /* Hello World */,
-      "prop4" /* Hello World ,,, * */ : "test3",,,,
-      "prop5": [
-        // Hello World!
-        /// Header
-        // /* */
-        0,
-        1, /* Hello World!
-        ,,,,,,,,,,
-        */
-      2, 3, 4,
-      ],
-      // /**********
-      /**
-       *
-       * Multi line Big Comment
-       */
-      /// Header
-      /// Subtext
-      ,,,,,,,,,,,,,,
-    }`;
+`{
+  // Hello World
+  "prop1": "test",
+  // Test
+  "prop2": "test2"
+  /* Hello World */,
+  "prop3": [ 123, /* Hello World */ "456",,, /* Hello World */ 789 ] /* Hello World */,
+  "prop4" /* Hello World ,,, * */ : "test3",,,,
+  "prop5": [          ,   ,  ,      , \r \r \r
+    // Hello World!
+    /// Header \r \r \n \n \r \n
+    // /* */
+    0,
+    1, /* Hello World!
+    ,,,,,,,,,,
+    */
+  2, 3, 4,
+  ],
+  // /**********
+  /**
+   *
+   * Multi line Big Comment
+   */
+  /// Header
+  /// Subtext
+  ,,,,,,,,,,,,,,
+}`;
     const expectedJsonc = { prop1: "test", prop2: "test2", prop3: [123, "456", 789], prop4: "test3", prop5: [0, 1, 2, 3, 4] };
+    const expectedPointers = {
+      "":{"value":{"line":0,"column":0,"pos":0},"valueEnd":{"line":27,"column":1,"pos":503}},
+      "/prop1":{"key":{"line":2,"column":2,"pos":21},"keyEnd":{"line":2,"column":9,"pos":28},"value":{"line":2,"column":11,"pos":30},"valueEnd":{"line":2,"column":17,"pos":36}},
+      "/prop2":{"key":{"line":4,"column":2,"pos":50},"keyEnd":{"line":4,"column":9,"pos":57},"value":{"line":4,"column":11,"pos":59},"valueEnd":{"line":4,"column":18,"pos":66}},
+      "/prop3":{"key":{"line":6,"column":2,"pos":90},"keyEnd":{"line":6,"column":9,"pos":97},"value":{"line":6,"column":11,"pos":99},"valueEnd":{"line":6,"column":66,"pos":156}},
+      "/prop3/0":{"value":{"line":6,"column":13,"pos":101},"valueEnd":{"line":6,"column":16,"pos":104}},
+      "/prop3/1":{"value":{"line":6,"column":35,"pos":124},"valueEnd":{"line":6,"column":40,"pos":129}},
+      "/prop3/2":{"value":{"line":6,"column":61,"pos":151},"valueEnd":{"line":6,"column":64,"pos":154}},
+      "/prop4":{"key":{"line":7,"column":2,"pos":178},"keyEnd":{"line":7,"column":9,"pos":185},"value":{"line":7,"column":35,"pos":212},"valueEnd":{"line":7,"column":42,"pos":219}},
+      "/prop5":{"key":{"line":8,"column":2,"pos":226},"keyEnd":{"line":8,"column":9,"pos":233},"value":{"line":8,"column":11,"pos":235},"valueEnd":{"line":20,"column":3,"pos":394}},
+      "/prop5/0":{"value":{"line":15,"column":4,"pos":332},"valueEnd":{"line":15,"column":5,"pos":333}},
+      "/prop5/1":{"value":{"line":16,"column":4,"pos":339},"valueEnd":{"line":16,"column":5,"pos":340}},
+      "/prop5/2":{"value":{"line":19,"column":2,"pos":382},"valueEnd":{"line":19,"column":3,"pos":383}},
+      "/prop5/3":{"value":{"line":19,"column":5,"pos":385},"valueEnd":{"line":19,"column":6,"pos":386}},
+      "/prop5/4":{"value":{"line":19,"column":8,"pos":388},"valueEnd":{"line":19,"column":9,"pos":389}}
+    };
 
     const badJsonc = `{ "prop1": "test" / }`;
     const badJsoncArr = `[ "test" / ]`;
@@ -333,12 +349,9 @@ describe('parse', function() {
     const jsonWithTrailingComma = `{ "prop1": "test1", "prop2": [1, 2, 3,] }`;
     const jsonObjWithTrailingComma = `{ "prop1": "test1", "prop2": [1, 2, 3]     , }`;
 
-    it("Should parse jsonc comments as whitespace and execute as normal if jsonc true", () => {
+    it("Should parse json with comments and trailing commas as whitespace and execute as normal if jsonc true", () => {
       assert.deepStrictEqual(jsonMap.parse(jsonc, null, { jsonc: true }).data, expectedJsonc);
-    });
-
-    it("Should parse trailing commas as valid if jsonc true", () => {
-      assert.deepStrictEqual(jsonMap.parse(jsonc, null, { jsonc: true }).data, expectedJsonc);
+      assert.deepStrictEqual(jsonMap.parse(jsonc, null, { jsonc: true }).pointers, expectedPointers);
     });
 
     it("Should throw errors on a / not followed by a * or another /", () => {
@@ -351,9 +364,9 @@ describe('parse', function() {
     });
 
     it("Should throw errors for invalid json if jsonc option false or not given and json contains comments or trailing commas", () => {
-      assert.throws(() => jsonMap.parse(jsonc, null, { jsonc: false }), /Unexpected token \/ in JSON at position 8/);
-      assert.throws(() => jsonMap.parse(jsonc, null, {}), /Unexpected token \/ in JSON at position 8/);
-      assert.throws(() => jsonMap.parse(jsonc), /Unexpected token \/ in JSON at position 8/);
+      assert.throws(() => jsonMap.parse(jsonc, null, { jsonc: false }), /Unexpected token \/ in JSON at position 4/);
+      assert.throws(() => jsonMap.parse(jsonc, null, {}), /Unexpected token \/ in JSON at position 4/);
+      assert.throws(() => jsonMap.parse(jsonc), /Unexpected token \/ in JSON at position 4/);
       assert.throws(() => jsonMap.parse(jsonWithTrailingComma), /Unexpected token ] in JSON at position 38/);
       assert.throws(() => jsonMap.parse(jsonObjWithTrailingComma), /Unexpected token } in JSON at position 45/);
     });


### PR DESCRIPTION
It'd be great if this project supported [jsonc](https://code.visualstudio.com/docs/languages/json#_json-with-comments). :)

**Changes**
- Added option `jsonc` which when set true will do the following:
- Add support for jsonc containing code comments like `//` or `/* ... */` (which is treated as whitespace)
- Add support for jsonc containing trailing commas

**Description of Changes**

I added a new function called `parseComment` in the style of the other `parseObject`, `parseArray`, `parseXXX` functions, which reads through code comments as whitespace when `jsonc` option is enabled.

When called this function parses through the source until it finds a valid comment termination and then returns to the original `whitespace` function to continue parsing whitespace.

I also adjusted `parseObject` and `parseArray` to allow for trailing commas if and only if `jsonc` option is enabled.